### PR TITLE
Add support for protected interceptors via di:compile command

### DIFF
--- a/Interception/Code/Generator/DiCompileInterceptor.php
+++ b/Interception/Code/Generator/DiCompileInterceptor.php
@@ -5,7 +5,7 @@
  */
 namespace Danslo\ProtectedInterceptors\Interception\Code\Generator;
 
-class Interceptor extends \Magento\Framework\Interception\Code\Generator\Interceptor
+class DiCompileInterceptor extends \Magento\Setup\Module\Di\Code\Generator\Interceptor
 {
     use GetClassMethodsTrait;
 }

--- a/Interception/Code/Generator/GetClassMethodsTrait.php
+++ b/Interception/Code/Generator/GetClassMethodsTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Danslo\ProtectedInterceptors\Interception\Code\Generator;
+
+trait GetClassMethodsTrait
+{
+    private $ignores = [
+        \Magento\Customer\Model\ResourceModel\CustomerRepository::class => ['addFilterGroupToCollection']
+    ];
+
+    /**
+     * Returns list of methods for class generator.
+     *
+     * Included protected method in our filter.
+     *
+     * @return array
+     * @throws \ReflectionException
+     */
+    protected function _getClassMethods()
+    {
+        $methods = [$this->_getDefaultConstructorDefinition()];
+        $reflectionClass = new \ReflectionClass($this->getSourceClassName());
+        $methodFilter = \ReflectionMethod::IS_PUBLIC;
+
+        // Working around a circular dependency issue for this specific class.
+        if (strpos($this->getSourceClassName(), '\Magento\Store\Model\ResourceModel') !== 0) {
+            $methodFilter |= \ReflectionMethod::IS_PROTECTED;
+        }
+
+        $interceptedMethods = $reflectionClass->getMethods($methodFilter);
+        foreach ($interceptedMethods as $method) {
+            if ($this->isInterceptedMethod($method) && !$this->isIgnoredMethod($method)) {
+                $methods[] = $this->_getMethodInfo($method);
+            }
+        }
+        return $methods;
+    }
+
+    /**
+     * Retrieve method info
+     *
+     * @param \ReflectionMethod $method
+     * @return array
+     */
+    protected function _getMethodInfo(\ReflectionMethod $method)
+    {
+        $methodInfo = parent::_getMethodInfo($method);
+        $methodInfo['visibility'] = $method->isProtected() ? 'protected' : 'public';
+        return $methodInfo;
+    }
+
+    private function isIgnoredMethod(\ReflectionMethod $method): bool
+    {
+        if (!isset($this->ignores[$method->getDeclaringClass()->getName()])) {
+            return false;
+        }
+
+        return in_array($method->getName(), $this->ignores[$method->getDeclaringClass()->getName()], true);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Magento\Framework\Interception\Code\Generator\Interceptor" type="Danslo\ProtectedInterceptors\Interception\Code\Generator\Interceptor" />
+    <preference for="Magento\Setup\Module\Di\Code\Generator\Interceptor" type="Danslo\ProtectedInterceptors\Interception\Code\Generator\DiCompileInterceptor" />
 </config>


### PR DESCRIPTION
So the `di:compile` command uses a different generator (one that extends the framework one). We can't extend that for both of them because it would break the framework one. I've refactored so that there are two interceptors, each extend the respective core generator. Then I've extracted our logic for getting protected as well as public methods in to a trait and imported that into both of the overrides. 